### PR TITLE
CR#18119 fix invalid path to file error when using git bash in VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ As you're on a Mac, make sure to use the correct Python version in that snippet,
 
 ### VS Code
 
-Add a new task (`Configure Tasks`) and name it `Teamscale Precommit Analysis` or similar. VS Code will open a sample `tasks.json` for you to edit. Locate `config/teamscale-precommit-vscode-task.json` in this repo. Copy and paste the snippet and modify to your needs (e.g. `python` vs. `python3`).
+Add a new task (`Terminal -> Configure Tasks`) and name it `Teamscale Precommit Analysis` or similar. VS Code will open a sample `tasks.json` for you to edit. Locate `config/teamscale-precommit-vscode-task.json` in this repo. Copy and paste the snippet and modify to your needs (e.g. `python` vs. `python3`).
 
 ### Vim
 

--- a/config/teamscale-precommit-vscode-task.json
+++ b/config/teamscale-precommit-vscode-task.json
@@ -4,7 +4,7 @@
         {
             "label": "Teamscale Precommit Analysis",
             "type": "shell",
-            "command": "python -c 'from teamscale_precommit_client.precommit_client import run;run()' ${file}",
+            "command": "${config:python.pythonPath} -c 'from teamscale_precommit_client.precommit_client import run;run()' '${file}'",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/teamscale_precommit_client/precommit_client.py
+++ b/teamscale_precommit_client/precommit_client.py
@@ -124,7 +124,7 @@ def configure_precommit_client(config_file, repo_path, parsed_args):
 def run():
     """Performs precommit analysis."""
     parsed_args = _parse_args()
-    repo_path = get_repo_root_from_file_in_repo(parsed_args.path[0])
+    repo_path = get_repo_root_from_file_in_repo(os.path.normpath(parsed_args.path[0]))
     if not repo_path or not os.path.exists(repo_path) or not os.path.isdir(repo_path):
         raise RuntimeError('Invalid path to file in repository: %s' % repo_path)
 


### PR DESCRIPTION
Should fix [TS-18119](https://jira.cqse.eu/browse/TS-18119). Problem is that \ in the input args are not seen by gitbash for whatever reason. Surrounding the filepath with ' alleviates this.